### PR TITLE
fix ampersand containing card names for mtg mate

### DIFF
--- a/src/stores/mtgmate_scraper_helper.py
+++ b/src/stores/mtgmate_scraper_helper.py
@@ -1,4 +1,5 @@
-""" MTG Mate Scraper Helper """
+"""MTG Mate Scraper Helper"""
+
 from cards.card import Card
 from decimal import Decimal
 from lxml import html
@@ -10,7 +11,7 @@ class MtgMateScraperHelper(ScraperHelper):
     """Scraper helper for scraping mtgmate.com"""
 
     def url(self, card: Card) -> str:
-        url_name = card.name.replace(" ", "_")
+        url_name = card.name.replace(" ", "_").replace("&", "%26")
         foil = ":foil" if card.printing == "Foil" else ""
         return f"https://www.mtgmate.com.au/cards/{url_name}/{card.set_code}/{card.number}{foil}"
 

--- a/tests/stores/mtgmate_scraper_helper_test.py
+++ b/tests/stores/mtgmate_scraper_helper_test.py
@@ -1,4 +1,4 @@
-""" test the scraper class """
+"""test the scraper class"""
 
 from cards.card import Card
 from stores.mtgmate_scraper_helper import MtgMateScraperHelper
@@ -22,6 +22,23 @@ def test_foil():
     url = helper.url(card)
 
     assert url == "https://www.mtgmate.com.au/cards/Boros_Guildgate/GRN/243:foil"
+
+
+def test_ampersand():
+    card = Card(
+        "Ishgard, the Holy See // Faith & Grief",
+        "FIN",
+        "Final Fantasy",
+        "283",
+        "Normal",
+    )
+    helper = MtgMateScraperHelper()
+    url = helper.url(card)
+
+    assert (
+        url
+        == "https://www.mtgmate.com.au/cards/Ishgard,_the_Holy_See_//_Faith_%26_Grief/FIN/283"
+    )
 
 
 def test_stock_xpath():


### PR DESCRIPTION
mtg mate urls are not compliant with url entities - for example commas are included